### PR TITLE
fix: restore benchmark RuboCop baseline

### DIFF
--- a/benchmarks/convergence_benchmark.rb
+++ b/benchmarks/convergence_benchmark.rb
@@ -223,7 +223,7 @@ missing_configs.each do |config|
   # Generate data with missing values
   base_data = generate_data(100, 50)[:data]
 
-  data_with_missing = if (config[:rate]).positive?
+  data_with_missing = if config[:rate].positive?
                         base_data.map do |row|
                           row.map { |resp| rand < config[:rate] ? nil : resp }
                         end


### PR DESCRIPTION
## Summary
Restores the RuboCop baseline for the benchmark suite by removing redundant parentheses around the missing-data rate check. This keeps the benchmark script style-compliant without changing runtime behavior.

## Changes
- Simplified the `config[:rate].positive?` condition in `benchmarks/convergence_benchmark.rb`.

## Test plan
- RSpec suite passed.
- RuboCop passed with no offenses.
- Gem build completed successfully.
