### PR TITLE
ci: add packaging quality gate

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,16 +10,17 @@ on:
 
 jobs:
   test:
-
-    runs-on: ubuntu-latest
+    # Ruby 2.6/2.7 are still in the compatibility matrix and need the older Ubuntu image.
+    runs-on: ubuntu-22.04
 
     strategy:
+      fail-fast: false
       matrix:
-        ruby-version: [2.6, 2.7, 3.0, 3.1]
+        ruby-version: ['2.6', '2.7', '3.0', '3.1']
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -29,3 +30,31 @@ jobs:
 
       - name: Run tests
         run: bundle exec rspec
+
+  quality:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+
+      - name: Run RuboCop
+        run: bundle exec rubocop
+
+      - name: Build gem package
+        run: |
+          mkdir -p pkg
+          gem build irt_ruby.gemspec -o pkg/irt_ruby.gem
+
+      - name: Verify built gem installs
+        run: |
+          set -euo pipefail
+          gem install pkg/irt_ruby.gem --no-document
+          cd "$(mktemp -d)"
+          env -u BUNDLE_GEMFILE -u BUNDLE_PATH ruby -e "require 'irt_ruby'; result = IrtRuby::RaschModel.new([[1, 0], [0, 1]]).fit; raise 'missing abilities' unless result[:abilities].size == 2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - Added executable specs for README usage examples to keep the documented Rasch, 2PL, 3PL, and missing-data flows aligned with the public API.
 
 ### Changed
+- Added CI RuboCop and gem package build/install verification, and documented the local quality and packaging commands for contributors.
 - Clarified that response data must be a `Matrix` or array of arrays containing only integer `0`, integer `1`, or `nil`; floats, strings, booleans, and other values are rejected.
 
 ---

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ See `benchmarks/README.md` for detailed information about interpreting results.
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake spec` for the test suite or `bundle exec rake` for the default local quality gate: the RSpec suite and RuboCop. Before tagging a release, run `bundle exec rake build` to verify the gemspec packages cleanly from the current file list; CI also installs the built gem and smoke-tests `require 'irt_ruby'`. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 


### PR DESCRIPTION
## Summary
Adds a dedicated CI quality job for irt_ruby so lint and package verification run alongside the existing Ruby compatibility test matrix. The new packaging check builds the gem, installs the built artifact, and smoke-tests the installed gem from a temporary directory.

## Changes
- Updates GitHub Actions to use `actions/checkout@v4`, quote Ruby matrix versions, and keep matrix failures visible across supported Rubies.
- Adds a CI quality job for RuboCop plus gem build/install verification.
- Updates contributor documentation and the changelog with the local quality and packaging commands.

## Test plan
- RSpec suite passed.
- RuboCop passed.
- Default Rake quality gate passed.
- Gem build, install, and installed-gem smoke test passed.
