### PR TITLE
docs: fix missing strategy keyword wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ puts three_pl_result[:guessings]
 ```
 
 ## Handling Missing Data
-Real-world data often has missing responses. Each model (Rasch, 2PL, 3PL) accepts a `missing_strategy: option` to handle nil entries:
+Real-world data often has missing responses. Each model (Rasch, 2PL, 3PL) accepts a `missing_strategy:` option to handle nil entries:
 
 - `:ignore` (default): Skip `nil` responses entirely in the log-likelihood and gradient calculations.
 - `:treat_as_incorrect`: Interpret `nil` as `0`.


### PR DESCRIPTION
## Summary
- Corrects the README missing-data wording so `missing_strategy:` is shown as a Ruby keyword option.
- Keeps the documented option name aligned with the surrounding example and model constructors.

## Changes
- Fixes the malformed inline code in the Handling Missing Data section.

## Test plan
- RSpec suite passed.
- RuboCop passed.
- Gem package build passed.
