### PR TITLE
docs: remove changelog placeholder note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,3 @@ All notable changes to this project are documented in this file.
 - This release remains **backward-compatible** with `0.1.x` in terms of existing usage; the default `:ignore` missing-data approach matches prior behavior.
 - If upgrading, simply update your gem and enjoy the new features.
 - For more details, see the updated [README](./README.md) and expanded test suites.
-
----
-
-*(If you have older versions below `0.2.0`, you can keep them documented similarly, e.g., `## [0.1.x] ...`, under this new entry.)*


### PR DESCRIPTION
## Summary
Remove a leftover maintainer placeholder from the changelog so the published history reads as project documentation rather than template guidance.

## Changes
- Delete the trailing placeholder note about documenting older versions.
- Remove the now-unused final separator after the 0.2.0 notes.

## Test plan
- RSpec suite passed.
- RuboCop passed with no offenses.
- Gem build completed successfully.
- Diff whitespace check passed.
