### PR TITLE
test: use constructor seeds in model specs

### DIFF
--- a/spec/irt_ruby/rasch_model_spec.rb
+++ b/spec/irt_ruby/rasch_model_spec.rb
@@ -160,14 +160,12 @@ RSpec.describe IrtRuby::RaschModel do
       end
     end
 
-    context "Deterministic seed" do
-      it "produces consistent results with the same seed" do
-        srand(123)
-        model1 = described_class.new(data_array, max_iter: 200, learning_rate: 0.05)
+    context "Constructor seed" do
+      it "produces consistent results with the same seed option" do
+        model1 = described_class.new(data_array, max_iter: 200, learning_rate: 0.05, seed: 123)
         result1 = model1.fit
 
-        srand(123)
-        model2 = described_class.new(data_array, max_iter: 200, learning_rate: 0.05)
+        model2 = described_class.new(data_array, max_iter: 200, learning_rate: 0.05, seed: 123)
         result2 = model2.fit
 
         expect(result1[:abilities]).to eq(result2[:abilities])
@@ -179,10 +177,11 @@ RSpec.describe IrtRuby::RaschModel do
       it "handles a moderately large dataset without error" do
         n_examinees = 20
         n_items = 10
+        rng = Random.new(123)
         big_data = Array.new(n_examinees) do
-          Array.new(n_items) { rand < 0.5 ? 1 : 0 }
+          Array.new(n_items) { rng.rand < 0.5 ? 1 : 0 }
         end
-        model = described_class.new(big_data, max_iter: 300, learning_rate: 0.05)
+        model = described_class.new(big_data, max_iter: 300, learning_rate: 0.05, seed: 123)
         expect { model.fit }.not_to raise_error
 
         results = model.fit

--- a/spec/irt_ruby/three_parameter_model_spec.rb
+++ b/spec/irt_ruby/three_parameter_model_spec.rb
@@ -210,14 +210,12 @@ RSpec.describe IrtRuby::ThreeParameterModel do
       end
     end
 
-    context "Deterministic seed" do
-      it "produces consistent results with the same seed" do
-        srand(123)
-        model1 = described_class.new(data_array, max_iter: 200, learning_rate: 0.05)
+    context "Constructor seed" do
+      it "produces consistent results with the same seed option" do
+        model1 = described_class.new(data_array, max_iter: 200, learning_rate: 0.05, seed: 123)
         result1 = model1.fit
 
-        srand(123)
-        model2 = described_class.new(data_array, max_iter: 200, learning_rate: 0.05)
+        model2 = described_class.new(data_array, max_iter: 200, learning_rate: 0.05, seed: 123)
         result2 = model2.fit
 
         expect(result1[:abilities]).to eq(result2[:abilities])
@@ -231,11 +229,12 @@ RSpec.describe IrtRuby::ThreeParameterModel do
       it "handles a moderately large dataset without error" do
         n_examinees = 20
         n_items = 8
+        rng = Random.new(123)
         big_data = Array.new(n_examinees) do
-          Array.new(n_items) { rand < 0.5 ? 1 : 0 }
+          Array.new(n_items) { rng.rand < 0.5 ? 1 : 0 }
         end
 
-        model = described_class.new(big_data, max_iter: 300, learning_rate: 0.05)
+        model = described_class.new(big_data, max_iter: 300, learning_rate: 0.05, seed: 123)
         expect { model.fit }.not_to raise_error
 
         results = model.fit

--- a/spec/irt_ruby/two_parameter_model_spec.rb
+++ b/spec/irt_ruby/two_parameter_model_spec.rb
@@ -169,14 +169,12 @@ RSpec.describe IrtRuby::TwoParameterModel do
       end
     end
 
-    context "Deterministic seed" do
-      it "yields consistent results with the same seed" do
-        srand(123)
-        model1 = described_class.new(data_array, max_iter: 200, learning_rate: 0.05)
+    context "Constructor seed" do
+      it "yields consistent results with the same seed option" do
+        model1 = described_class.new(data_array, max_iter: 200, learning_rate: 0.05, seed: 123)
         result1 = model1.fit
 
-        srand(123)
-        model2 = described_class.new(data_array, max_iter: 200, learning_rate: 0.05)
+        model2 = described_class.new(data_array, max_iter: 200, learning_rate: 0.05, seed: 123)
         result2 = model2.fit
 
         expect(result1[:abilities]).to eq(result2[:abilities])
@@ -189,11 +187,12 @@ RSpec.describe IrtRuby::TwoParameterModel do
       it "handles a moderately sized dataset without error" do
         n_examinees = 20
         n_items = 8
+        rng = Random.new(123)
         big_data = Array.new(n_examinees) do
-          Array.new(n_items) { rand < 0.5 ? 1 : 0 }
+          Array.new(n_items) { rng.rand < 0.5 ? 1 : 0 }
         end
 
-        model = described_class.new(big_data, max_iter: 300, learning_rate: 0.05)
+        model = described_class.new(big_data, max_iter: 300, learning_rate: 0.05, seed: 123)
         expect { model.fit }.not_to raise_error
 
         results = model.fit


### PR DESCRIPTION
## Summary
Model determinism specs now exercise the public constructor `seed:` option instead of resetting Ruby's global random number generator. The large generated datasets in the model specs also use local random generators so those smoke fixtures remain reproducible without polluting process-wide RNG state.

## Changes
- Updated Rasch, 2PL, and 3PL per-model deterministic examples to pass `seed:` directly to constructors.
- Replaced global random fixture generation with local `Random.new` instances.
- Seeded the corresponding model construction in large-dataset smoke tests for easier failure reproduction.

## Test plan
- Targeted model specs passed for Rasch, 2PL, and 3PL.
- Full RSpec suite passed.
- RuboCop passed with no offenses.
- Gem package build completed successfully.